### PR TITLE
Added note about PHP version support to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,14 @@ on the sniffs, the following installation steps are required.
 6. Run the tests by running `phpunit` in the root directory of
    PHPCompatibility. It will read the `phpunit.xml` file and execute the tests
 
+PHP Version Support
+-------
+
+The project aims to cover all PHP compatibility changes introduced since PHP 5.0 up to the latest PHP release.  This is an ongoing process and coverage is not yet 100% (if, indeed, it ever could be).  Progress is tracked on [our Github issue tracker](https://github.com/wimg/PHPCompatibility/issues).
+
+Although we do not intend to work on it ourselves, we will accept pull requests that check for compatibility issues in PHP4 code (in particular between PHP 4 and PHP 5.0) as there may still be situations where people need help upgrading legacy systems.  However, coverage for changes introduced in PHP up to and including 5.0 will remain patchy as supporting older versions is not a primary aim at this time.
+
+The sniffs are designed to give the same results regardless of which PHP version you are using to run CodeSniffer.  Therefore you should get consistent results across different testing systems.
 
 License
 -------


### PR DESCRIPTION
As discussed in #141 it would be sensible to document what versions of PHP are supported, both for running the sniff and for the compatibility checks it contains.

I hope I have accurately captured the current state of the project in this regard, but please amend as necessary.
